### PR TITLE
Install failed due to architecture mismatch #3: Converts x86_64 to amd64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -42,6 +42,10 @@ download_release() {
 	local tag os arch
 	tag="v${version}"
 	arch=$(uname -m)
+	if [ "$arch" == "x86_64" ] 
+	then
+		arch="amd64"
+	fi
 	os=$(uname -s)
 	os=$(echo ${os} | tr '[:upper:]' '[:lower:]') # Convert the OS name to lowercase
 


### PR DESCRIPTION
Converts x86_64 arch to amd64 as thats the arch that available 