### PR TITLE
Deprecate asdf-dojo in favor of individual plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,19 @@
 <div align="center">
 
-# asdf-dojo
+# asdf-dojo (DEPRECATED)
 
-[Dojo](https://github.com/dojoengine/dojo) plugin for the [asdf version manager](https://asdf-vm.com).
+> **This plugin is deprecated.**
+> Dojo components are now released independently.
+> Please use the individual plugins instead:
+>
+> - [asdf-sozo](https://github.com/dojoengine/asdf-sozo)
+> - [asdf-katana](https://github.com/dojoengine/asdf-katana)
+> - [asdf-torii](https://github.com/dojoengine/asdf-torii)
+> - [asdf-saya](https://github.com/dojoengine/asdf-saya)
+>
+> To install the full toolchain:
+> ```shell
+> curl -L https://install.dojoengine.org | bash
+> ```
 
 </div>
-
-# Contents
-
-- [Dependencies](#dependencies)
-- [Install](#install)
-- [Contributing](#contributing)
-- [License](#license)
-
-# Dependencies
-
-**TODO: adapt this section**
-
-- `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
-
-# Install
-
-Plugin:
-
-```shell
-# Always use the full URL to ensure no ambiguity with other plugins.
-asdf plugin add dojo https://github.com/dojoengine/asdf-dojo.git
-```
-
-If you already had dojo installed and you want to force the update, two choices:
-1. Modifying your `~/.asdfrc` and set the [last check duration](asdf plugin add dojo https://github.com/dojoengine/asdf-dojo.git) to 0.
-2. Remove and re-add the plugin:
-```bash
-asdf plugin remove dojo
-asdf plugin add dojo https://github.com/dojoengine/asdf-dojo.git
-```
-
-Dojo:
-
-```shell
-# Show all installable versions
-asdf list-all dojo
-
-# Install specific version
-asdf install dojo latest
-
-# Set a version globally (on your ~/.tool-versions file)
-asdf global dojo latest
-
-# Now dojo commands are available
-katana --version
-```
-
-Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
-install & manage versions.
-
-# Contributing
-
-Contributions of any kind welcome! See the [contributing guide](contributing.md).
-
-[Thanks goes to these contributors](https://github.com/dojoengine/asdf-dojo/graphs/contributors)!
-
-# License
-
-See [LICENSE](LICENSE) © [dojoengine](https://github.com/dojoengine/)


### PR DESCRIPTION
## Summary
- Replace README with deprecation notice pointing to asdf-sozo, asdf-katana, asdf-torii, and asdf-saya
- Dojo components are now released independently, so this monolithic plugin is no longer appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)